### PR TITLE
文書型宣言の前の空行を削除

### DIFF
--- a/html/webapp/templates/main/header.html
+++ b/html/webapp/templates/main/header.html
@@ -1,4 +1,3 @@
-
 <{strip}>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<{$header_field.meta_language}>" lang="<{$header_field.meta_language}>">


### PR DESCRIPTION
ソース見たときに気持ち悪いので。
あっても文法違反ではないし，表示に支障はないが。
