### PR TITLE
メールアドレス欄が複数ある場合の対応 by nagahara@opensource-workshop.jp

### DIFF
--- a/html/webapp/modules/backup/components/Restore.class.php
+++ b/html/webapp/modules/backup/components/Restore.class.php
@@ -214,7 +214,11 @@ class Backup_Components_Restore
 		//$options = array ('parseAttributes' => true);	属性値を含める
 		//$unserializer =& new XML_Unserializer($options);
 
-		$result = $unserializer->unserialize($xml);
+		// XML を読み込んだ変数から処理すると、環境によってはメモリを使いすぎてエラーになるケースがあった。
+		// そのため、XML は再度、ファイルから取得するように修正し、メモリの消費を抑えた。
+		// 2014-08-15 by nagahara@opensource-workshop.jp
+		// $result = $unserializer->unserialize($xml);
+		$result = $unserializer->unserialize($temporary_file_path.BACKUP_ROOM_XML_FILE_NAME, true);
 		if($result !== true) {
 			$this->_fileAction->delDir($temporary_file_path);
 			$errorList->add("backup", BACKUP_FAILURE_UNSERIALIZE);

--- a/html/webapp/modules/registration/action/main/mail/Mail.class.php
+++ b/html/webapp/modules/registration/action/main/mail/Mail.class.php
@@ -61,7 +61,13 @@ class Registration_Action_Main_Mail extends Action
 		$users = array();
 		if ($mail['regist_user_send']
 			&& !empty($mail['regist_user_email'])) {
-			$users[]['email'] = $mail['regist_user_email'];
+
+			// メールアドレス欄が複数ある場合の対応 by nagahara@opensource-workshop.jp
+			// $users[]['email'] = $mail['regist_user_email'];
+			foreach( $mail['regist_user_email'] as $mail_item ) {
+				$users[]['email'] = $mail_item;
+			}
+
 			$this->mailMain->setToUsers($users);
 			$this->mailMain->send();
 		}

--- a/html/webapp/modules/registration/components/View.class.php
+++ b/html/webapp/modules/registration/components/View.class.php
@@ -741,7 +741,9 @@ class Registration_Components_View
 				}
 
 				if ($item['item_type'] == REGISTRATION_TYPE_EMAIL) {
-					$mail['regist_user_email'] = $row[$key];
+					// メールアドレス欄が複数ある場合の対応 by nagahara@opensource-workshop.jp
+					// $mail['regist_user_email'] = $row[$key];
+					$mail['regist_user_email'][] = $row[$key];
 				}
 
 				$mail["data"] .= sprintf($dataFormat,  htmlspecialchars($item["item_name"]), $value);


### PR DESCRIPTION
登録フォームに複数のメールアドレス型の項目がある場合、最後のメールアドレスにしか、メールが送信されない。
これをメールアドレス型の項目があれば、全てに送信するように修正。
